### PR TITLE
Now uses the Ghost navigation settings to populate navigation menu

### DIFF
--- a/index.hbs
+++ b/index.hbs
@@ -10,7 +10,7 @@
 </header>
 
 {{! Comment this if you are not using static pages }}
-{{> menu}}
+{{navigation}}
 
 {{! The main content area on the homepage }}
 <main>

--- a/page.hbs
+++ b/page.hbs
@@ -14,7 +14,7 @@
 </header>
 
 {{! Comment this if you are not using static pages}}
-{{> menu}}
+{{navigation}}
 
 <main>
     {{#post}}

--- a/partials/menu.hbs
+++ b/partials/menu.hbs
@@ -1,4 +1,0 @@
-<nav class="main-menu"><ul>
-    <li><a href="/about/">About</a></li>
-    {{! Add there all your static pages}}
-</ul></nav>

--- a/partials/navigation.hbs
+++ b/partials/navigation.hbs
@@ -1,0 +1,6 @@
+<nav class="main-menu"><ul>
+    {{! Add there all your static pages}}
+    {{#foreach navigation}}
+        <li class="nav-{{slug}}{{#if current}} nav-current{{/if}}" role="presentation"><a href="{{url absolute="true"}}">{{label}}</a></li>
+    {{/foreach}}
+</ul></nav>


### PR DESCRIPTION
This way users won't need to edit the partials/menu.hbs file directly. Instead they will be able to use the navigation setting in the admin dashboard. It only works if the partial is named navigation.hbs so I had to rename the file.